### PR TITLE
Set clipsToBounds to true

### DIFF
--- a/GlkView/GlkWindow.m
+++ b/GlkView/GlkWindow.m
@@ -22,6 +22,7 @@
 	if (self) {
 		border = 4;
 		scaleFactor = 1.0;
+		self.clipsToBounds = YES;
 	}
     
 	return self;


### PR DESCRIPTION
macOS Sonoma no longer sets the clipsToBounds property on NSView to true by default, which causes display glitches.

See: https://github.com/TobyLobster/Inform/issues/43