### PR TITLE
Switch off smart quotes when entering text

### DIFF
--- a/GlkView/GlkTextWindow.m
+++ b/GlkView/GlkTextWindow.m
@@ -68,7 +68,8 @@
 	[textView setEditable: NO];
     [textView setRichText: YES];
 	[textView setUsesFindPanel: YES];
-	
+	[textView setAutomaticQuoteSubstitutionEnabled: NO];
+
 	inputPos = 0;
 	[[textView textStorage] setDelegate: self];
 	[textView setDelegate: self];


### PR DESCRIPTION
Curly quotes can cause problems in many games, so let's not convert straight ones to curly by default.