### PR TITLE
Fix crash in glk_buffer_to_title_case_uni

### DIFF
--- a/GlkClient/glk_unicode.m
+++ b/GlkClient/glk_unicode.m
@@ -189,9 +189,11 @@ glui32 glk_buffer_to_title_case_uni(glui32 *buf, glui32 len,
 				// Scan any whitespace at the start of the string
 				[stringScanner scanCharactersFromSet: whitespace
 										  intoString: &lastWhitespace];
-				
-				[result appendString: lastWhitespace];
-				
+
+				if (lastWhitespace) {
+					[result appendString: lastWhitespace];
+				}
+
 				// Give up if there's nothing following the whitespace
 				if ([stringScanner isAtEnd]) break;
 				


### PR DESCRIPTION
`[(NSMutableString *)result appendString:lastWhitespace]` will crash if `lastWhitespace` is nil, i.e. if the input contains no white space. Fixes Mac Inform IDE issue #41: https://github.com/TobyLobster/Inform/issues/41