### PR TITLE
Use a weak reference for the line selection delegate.

### DIFF
--- a/GlkView/GlkTypesetter.h
+++ b/GlkView/GlkTypesetter.h
@@ -91,7 +91,7 @@ typedef NS_ENUM(int, GlkSectionAlignment) {
 @property GlkSectionAlignment alignment;
 
 /// A line section delegate object.
-@property (assign) id<GlkCustomLineSection> delegate;
+@property (weak) id<GlkCustomLineSection> delegate;
 /// Whether or not this is an elastic line section (used in full-justification).
 @property (getter=isElastic) BOOL elastic;
 


### PR DESCRIPTION
Xcode pointed this out while I was getting oriented in the project. Helpful! Might explain some of the random segfaults.